### PR TITLE
Replaced InputStream with Reader in (load-from) for java.io.File

### DIFF
--- a/src/clojure/clojurewerkz/propertied/properties.clj
+++ b/src/clojure/clojurewerkz/propertied/properties.clj
@@ -64,9 +64,9 @@
 
   java.io.File
   (load-from [input]
-    (with-open [is (io/input-stream input)]
+    (with-open [rdr (io/reader input)]
       (doto (Properties.)
-        (.load is))))
+        (.load rdr))))
 
   java.net.URL
   (load-from [input]


### PR DESCRIPTION
`InputStream` assumes  ISO 8859-1 encoding, giving erroneous output for `.properties` files with diacritics

(e.g. this issue https://github.com/michaelklishin/propertied/issues/6)